### PR TITLE
CVE-2023-28464 - FIP8-plus 

### DIFF
--- a/net/bluetooth/hci_conn.c
+++ b/net/bluetooth/hci_conn.c
@@ -135,13 +135,11 @@ static void hci_conn_cleanup(struct hci_conn *conn)
 			hdev->notify(hdev, HCI_NOTIFY_CONN_DEL);
 	}
 
-	hci_conn_del_sysfs(conn);
-
 	debugfs_remove_recursive(conn->debugfs);
 
-	hci_dev_put(hdev);
+	hci_conn_del_sysfs(conn);
 
-	hci_conn_put(conn);
+	hci_dev_put(hdev);
 }
 
 static void le_scan_cleanup(struct work_struct *work)

--- a/net/bluetooth/hci_sysfs.c
+++ b/net/bluetooth/hci_sysfs.c
@@ -33,7 +33,7 @@ void hci_conn_init_sysfs(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("conn %p", conn);
+	bt_dev_dbg(hdev, "conn %p", conn);
 
 	conn->dev.type = &bt_link;
 	conn->dev.class = bt_class;
@@ -46,24 +46,27 @@ void hci_conn_add_sysfs(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("conn %p", conn);
+	bt_dev_dbg(hdev, "conn %p", conn);
 
 	dev_set_name(&conn->dev, "%s:%d", hdev->name, conn->handle);
 
-	if (device_add(&conn->dev) < 0) {
+	if (device_add(&conn->dev) < 0)
 		bt_dev_err(hdev, "failed to register connection device");
-		return;
-	}
-
-	hci_dev_hold(hdev);
 }
 
 void hci_conn_del_sysfs(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	if (!device_is_registered(&conn->dev))
+	bt_dev_dbg(hdev, "conn %p", conn);
+
+	if (!device_is_registered(&conn->dev)) {
+		/* If device_add() has *not* succeeded, use *only* put_device()
+		 * to drop the reference count.
+		 */
+		put_device(&conn->dev);
 		return;
+	}
 
 	while (1) {
 		struct device *dev;
@@ -75,9 +78,7 @@ void hci_conn_del_sysfs(struct hci_conn *conn)
 		put_device(dev);
 	}
 
-	device_del(&conn->dev);
-
-	hci_dev_put(hdev);
+	device_unregister(&conn->dev);
 }
 
 static void bt_host_release(struct device *dev)


### PR DESCRIPTION
Sync from internal `kernel-src-git`

# Original Commit from `kernel-src-git`

https://ciqinc.atlassian.net/browse/LE-1630

## Build
```
[TIMER]{MRPROPER}: 7s
  LD [M]  virt/lib/irqbypass.ko
+ '[' 0 -ne 0 ']'
++ date +%s
+ END_BUILD=1721844389
+ echo '[TIMER]{BUILD}: 1690s'
[TIMER]{BUILD}: 1690s
  DEPMOD  4.18.0-CVE-2023-28464+
+ '[' 0 -ne 0 ']'
++ date +%s
+ END_MODULES=1721847268
+ echo '[TIMER]{MODULES}: 41s'
[TIMER]{MODULES}: 41s
sh ./arch/x86/boot/install.sh 4.18.0-CVE-2023-28464+ arch/x86/boot/bzImage \
	System.map "/boot"
+ '[' 0 -ne 0 ']'
++ date +%s
+ END_INSTALL=1721847287
+ echo '[TIMER]{INSTALL}: 19s'
[TIMER]{INSTALL}: 19s
```

## Boot test
```
[maple@r86-fips kernel-src-git]$ sudo reboot
Connection to 192.168.122.119 closed by remote host.
Connection to 192.168.122.119 closed.
[jmaple@devbox ~]$ ssh -i ~/.ssh/libvirt_test maple@192.168.122.119
Activate the web console with: systemctl enable --now cockpit.socket

Last login: Wed Jul 24 18:24:57 2024 from 192.168.122.1
[maple@r86-fips ~]$ uname- a
-bash: uname-: command not found
[maple@r86-fips ~]$ uname -a
Linux r86-fips 4.18.0-CVE-2023-28464+ #1 SMP Wed Jul 24 18:25:31 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```

## Kselftests
```
[maple@r86-fips kernel-src-git]$ sudo make summary=1 kselftest
make --no-builtin-rules ARCH=x86 -C ../../.. headers_install
make[2]: Entering directory '/mnt/code/kernel-src-git'
make[2]: Leaving directory '/mnt/code/kernel-src-git'

make[2]: Entering directory '/mnt/code/kernel-src-git/tools/testing/selftests/zram'
TAP version 13
1..1
# selftests: zram: zram.sh
^Cmake[2]: *** [../lib.mk:86: run_tests] Interrupt
make[1]: *** [Makefile:160: run_tests] Interrupt
make: *** [Makefile:1264: kselftest] Interrupt

```

## Scan For Fixes
```
[jmaple@devbox kernel-src-git]$ ~/git_sources/kernel-tool-gh-pure/scanforfixes.py  --upstream-remote /home/jmaple/git_sources/linux --upstream-remote kernel-mainline
Fetching upstream None:kernel-mainline
Upstream fetched
Scan for all commits with fixes in the range v4.18..HEAD
53669 commits found with fixes
Switching to ./{jmaple}_CVE-2023-28464
```

## Original Commit Message
```
jira LE-1630
cve CVE-2023-28464
commit a85fb91e3d728bdfc80833167e8162cce8bc7004

syzbot reports a slab use-after-free in hci_conn_hash_flush [1]. After releasing an object using hci_conn_del_sysfs in the hci_conn_cleanup function, releasing the same object again using the hci_dev_put and hci_conn_put functions causes a double free. Here's a simplified flow:

hci_conn_del_sysfs:
  hci_dev_put
    put_device
      kobject_put
        kref_put
          kobject_release
            kobject_cleanup
              kfree_const
                kfree(name)

hci_dev_put:
  ...
    kfree(name)

hci_conn_put:
  put_device
    ...
      kfree(name)

This patch drop the hci_dev_put and hci_conn_put function call in hci_conn_cleanup function, because the object is freed in hci_conn_del_sysfs function.

This patch also fixes the refcounting in hci_conn_add_sysfs() and hci_conn_del_sysfs() to take into account device_add() failures.

This fixes CVE-2023-28464.

Link: https://syzkaller.appspot.com/bug?id=1bb51491ca5df96a5f724899d1dbb87afda61419 [1]

	Signed-off-by: ZhengHan Wang <wzhmmmmm@gmail.com>
Co-developed-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
	Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
(cherry picked from commit a85fb91e3d728bdfc80833167e8162cce8bc7004)
```