### PR TITLE
r8 compat sync

### DIFF
--- a/net/atm/ioctl.c
+++ b/net/atm/ioctl.c
@@ -71,14 +71,17 @@ static int do_vcc_ioctl(struct socket *sock, unsigned int cmd,
 	case SIOCINQ:
 	{
 		struct sk_buff *skb;
+		int amount;
 
 		if (sock->state != SS_CONNECTED) {
 			error = -EINVAL;
 			goto done;
 		}
+		spin_lock_irq(&sk->sk_receive_queue.lock);
 		skb = skb_peek(&sk->sk_receive_queue);
-		error = put_user(skb ? skb->len : 0,
-				 (int __user *)argp) ? -EFAULT : 0;
+		amount = skb ? skb->len : 0;
+		spin_unlock_irq(&sk->sk_receive_queue.lock);
+		error = put_user(amount, (int __user *)argp) ? -EFAULT : 0;
 		goto done;
 	}
 	case SIOCGSTAMP: /* borrowed from IP */

--- a/net/bluetooth/af_bluetooth.c
+++ b/net/bluetooth/af_bluetooth.c
@@ -263,11 +263,14 @@ int bt_sock_recvmsg(struct socket *sock, struct msghdr *msg, size_t len,
 	if (flags & MSG_OOB)
 		return -EOPNOTSUPP;
 
+	lock_sock(sk);
+
 	skb = skb_recv_datagram(sk, flags, noblock, &err);
 	if (!skb) {
 		if (sk->sk_shutdown & RCV_SHUTDOWN)
-			return 0;
+			err = 0;
 
+		release_sock(sk);
 		return err;
 	}
 
@@ -292,6 +295,8 @@ int bt_sock_recvmsg(struct socket *sock, struct msghdr *msg, size_t len,
 	}
 
 	skb_free_datagram(sk, skb);
+
+	release_sock(sk);
 
 	if (flags & MSG_TRUNC)
 		copied = skblen;

--- a/net/bluetooth/af_bluetooth.c
+++ b/net/bluetooth/af_bluetooth.c
@@ -263,14 +263,11 @@ int bt_sock_recvmsg(struct socket *sock, struct msghdr *msg, size_t len,
 	if (flags & MSG_OOB)
 		return -EOPNOTSUPP;
 
-	lock_sock(sk);
-
 	skb = skb_recv_datagram(sk, flags, noblock, &err);
 	if (!skb) {
 		if (sk->sk_shutdown & RCV_SHUTDOWN)
 			err = 0;
 
-		release_sock(sk);
 		return err;
 	}
 
@@ -295,8 +292,6 @@ int bt_sock_recvmsg(struct socket *sock, struct msghdr *msg, size_t len,
 	}
 
 	skb_free_datagram(sk, skb);
-
-	release_sock(sk);
 
 	if (flags & MSG_TRUNC)
 		copied = skblen;
@@ -520,10 +515,11 @@ int bt_sock_ioctl(struct socket *sock, unsigned int cmd, unsigned long arg)
 		if (sk->sk_state == BT_LISTEN)
 			return -EINVAL;
 
-		lock_sock(sk);
+		spin_lock(&sk->sk_receive_queue.lock);
 		skb = skb_peek(&sk->sk_receive_queue);
 		amount = skb ? skb->len : 0;
-		release_sock(sk);
+		spin_unlock(&sk->sk_receive_queue.lock);
+
 		err = put_user(amount, (int __user *)arg);
 		break;
 


### PR DESCRIPTION
Additional CVEs:
```
CVE-2023-51779 
CVE-2023-51780 
```

## BUILD
```
$ ../kernel_build.sh
/mnt/code/fips-kernel-src-git
  CLEAN   scripts/basic
  CLEAN   scripts/kconfig
  CLEAN   include/config include/generated
  CLEAN   .config
[TIMER]{MRPROPER}: 4s
x86_64 architecture detected, copying config
'configs/kernel-x86_64.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-jmaple_r8-compat_sync"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c

  LD [M]  sound/xen/snd_xen_front.ko
  LD [M]  virt/lib/irqbypass.ko
[TIMER]{BUILD}: 1667s
Making Modules
  INSTALL arch/x86/crypto/blowfish-x86_64.ko
  INSTALL arch/x86/crypto/camellia-aesni-avx-x86_64.ko

  INSTALL sound/xen/snd_xen_front.ko
  INSTALL virt/lib/irqbypass.ko
  DEPMOD  4.18.0-jmaple_r8-compat_sync+
[TIMER]{MODULES}: 44s
Making Install
sh ./arch/x86/boot/install.sh 4.18.0-jmaple_r8-compat_sync+ arch/x86/boot/bzImage \
	System.map "/boot"
[TIMER]{INSTALL}: 20s
Checking kABI
kABI check passed
Setting Default Kernel to /boot/vmlinuz-4.18.0-jmaple_r8-compat_sync+ and Index to 10
The default is /boot/loader/entries/918d66d9dcdb42338c7341ec3dbe2847-4.18.0-jmaple_r8-compat_sync+.conf with index 10 and kernel /boot/vmlinuz-4.18.0-jmaple_r8-compat_sync+
The default is /boot/loader/entries/918d66d9dcdb42338c7341ec3dbe2847-4.18.0-jmaple_r8-compat_sync+.conf with index 10 and kernel /boot/vmlinuz-4.18.0-jmaple_r8-compat_sync+
Generating grub configuration file ...
done
Hopefully Grub2.0 took everything ... rebooting after time metrices
[TIMER]{MRPROPER}: 4s
[TIMER]{BUILD}: 1667s
[TIMER]{MODULES}: 44s
[TIMER]{INSTALL}: 20s
[TIMER]{TOTAL} 1738s
Rebooting in 10 seconds
Connection to 192.168.122.119 closed by remote host.
Connection to 192.168.122.119 closed.
```

## kABI Check
```
Checking kABI
kABI check passed
```

## Reboot Test
```
Rebooting in 10 seconds
Connection to 192.168.122.119 closed by remote host.
Connection to 192.168.122.119 closed.
[jmaple@devbox ~]$ ssh -i ~/.ssh/libvirt_test maple@192.168.122.119
Activate the web console with: systemctl enable --now cockpit.socket

Last login: Thu Aug  8 18:41:05 2024 from 192.168.122.1
[maple@r86-fips ~]$ uname -a
Linux r86-fips 4.18.0-jmaple_r8-compat_sync+ #1 SMP Thu Aug 8 19:15:01 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```

## KernelSelfTests
```
[maple@r86-fips fips-kernel-src-git]$ sudo make SKIP_TARGETS="zram x86 mlock-random-test vm" summary=1 kselftest
make --no-builtin-rules ARCH=x86 -C ../../.. headers_install
make[2]: Entering directory '/mnt/code/fips-kernel-src-git'
make[2]: Leaving directory '/mnt/code/fips-kernel-src-git'
make[2]: Entering directory '/mnt/code/fips-kernel-src-git/tools/testing/selftests/android'
make[3]: Entering directory '/mnt/code/fips-kernel-src-git/tools/testing/selftests/android/ion'
gcc  -I. -I../../../../../drivers/staging/android/uapi/ -I../../../../../usr/include/ -Wall -O2 -g    ionapp_export.c ipcsocket.c ionutils.c   -o ionapp_export
ionapp_export.c: In function ‘main’:
ionapp_export.c:91:2: warning: ‘heap_type’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  printf("heap_type: %ld, heap_size: %ld\n", heap_type, heap_size);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gcc  -I. -I../../../../../drivers/staging/android/uapi/ -I../../../../../usr/include/ -Wall -O2 -g    ionapp_import.c ipcsocket.c ionutils.c   -o ionapp_import

make[2]: Entering directory '/mnt/code/fips-kernel-src-git/tools/testing/selftests/user'
TAP version 13
1..1
# selftests: user: test_user_copy.sh
ok 1 selftests: user: test_user_copy.sh # SKIP
make[2]: Leaving directory '/mnt/code/fips-kernel-src-git/tools/testing/selftests/user'
[maple@r86-fips fips-kernel-src-git]$
```
