### PR TITLE
Reverting update where crypto_chiper_setkey was removed

### DIFF
--- a/crypto/essiv.c
+++ b/crypto/essiv.c
@@ -119,9 +119,11 @@ static int essiv_aead_setkey(struct crypto_aead *tfm, const u8 *key,
 	crypto_cipher_clear_flags(tctx->essiv_cipher, CRYPTO_TFM_REQ_MASK);
 	crypto_cipher_set_flags(tctx->essiv_cipher, crypto_aead_get_flags(tfm) &
 						    CRYPTO_TFM_REQ_MASK);
+	err = crypto_cipher_setkey(tctx->essiv_cipher, salt,
+				    crypto_shash_digestsize(tctx->hash));
 out:
 	memzero_explicit(&keys, sizeof(keys));
-    return err;
+	return err;
 }
 
 static int essiv_aead_setauthsize(struct crypto_aead *tfm,


### PR DESCRIPTION
This is a fix for an issue introduced in commit [8871ab10133b8c36946f126e345b2a6a10cf0373](https://github.com/ciq-rocky-fips/kernel/commit/8871ab10133b8c36946f126e345b2a6a10cf0373)

The crypto_cipher_setkey function was mistakenly removed. We are adding the function back in.